### PR TITLE
Allow API Testing on API Platforms

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-const isPublicRoute = createRouteMatcher(["/login(.*)", "/signup(.*)"]);
+const isPublicRoute = createRouteMatcher(["/login(.*)", "/signup(.*)", "/api(.*)"]);
 
 export default clerkMiddleware(async (auth, request) => {
   if (!isPublicRoute(request)) {


### PR DESCRIPTION
## Developer: Kyle Taschek

### Pull Request Summary

Make API routes part of the public list so clerk doesn't block devs from testing via API platforms like postman.

### Modifications

`src/middleware.ts`
- add `, "/api(.*)"` to public route matcher

### Testing Considerations
NA

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers
