### PR TITLE
feat: allow admin to create & assign new user via sessionStorage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3382,6 +3382,126 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.26.tgz",
+      "integrity": "sha512-U0adH5ryLfmTDkahLwG9sUQG2L0a9rYux8crQeC92rPhi3jGQEY47nByQHrVrt3prZigadwj/2HZ1LUUimuSbg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.26.tgz",
+      "integrity": "sha512-SINMl1I7UhfHGM7SoRiw0AbwnLEMUnJ/3XXVmhyptzriHbWvPPbbm0OEVG24uUKhuS1t0nvN/DBvm5kz6ZIqpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.26.tgz",
+      "integrity": "sha512-s6JaezoyJK2DxrwHWxLWtJKlqKqTdi/zaYigDXUJ/gmx/72CrzdVZfMvUc6VqnZ7YEvRijvYo+0o4Z9DencduA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.26.tgz",
+      "integrity": "sha512-FEXeUQi8/pLr/XI0hKbe0tgbLmHFRhgXOUiPScz2hk0hSmbGiU8aUqVslj/6C6KA38RzXnWoJXo4FMo6aBxjzg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.26.tgz",
+      "integrity": "sha512-BUsomaO4d2DuXhXhgQCVt2jjX4B4/Thts8nDoIruEJkhE5ifeQFtvW5c9JkdOtYvE5p2G0hcwQ0UbRaQmQwaVg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.26.tgz",
+      "integrity": "sha512-5auwsMVzT7wbB2CZXQxDctpWbdEnEW/e66DyXO1DcgHxIyhP06awu+rHKshZE+lPLIGiwtjo7bsyeuubewwxMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
+      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.26.tgz",
+      "integrity": "sha512-2rdB3T1/Gp7bv1eQTTm9d1Y1sv9UuJ2LAwOE0Pe2prHKe32UNscj7YS13fRB37d0GAiGNR+Y7ZcW8YjDI8Ns0w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -16615,126 +16735,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.26.tgz",
-      "integrity": "sha512-U0adH5ryLfmTDkahLwG9sUQG2L0a9rYux8crQeC92rPhi3jGQEY47nByQHrVrt3prZigadwj/2HZ1LUUimuSbg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.26.tgz",
-      "integrity": "sha512-SINMl1I7UhfHGM7SoRiw0AbwnLEMUnJ/3XXVmhyptzriHbWvPPbbm0OEVG24uUKhuS1t0nvN/DBvm5kz6ZIqpg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.26.tgz",
-      "integrity": "sha512-s6JaezoyJK2DxrwHWxLWtJKlqKqTdi/zaYigDXUJ/gmx/72CrzdVZfMvUc6VqnZ7YEvRijvYo+0o4Z9DencduA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.26.tgz",
-      "integrity": "sha512-FEXeUQi8/pLr/XI0hKbe0tgbLmHFRhgXOUiPScz2hk0hSmbGiU8aUqVslj/6C6KA38RzXnWoJXo4FMo6aBxjzg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.26.tgz",
-      "integrity": "sha512-BUsomaO4d2DuXhXhgQCVt2jjX4B4/Thts8nDoIruEJkhE5ifeQFtvW5c9JkdOtYvE5p2G0hcwQ0UbRaQmQwaVg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.26.tgz",
-      "integrity": "sha512-5auwsMVzT7wbB2CZXQxDctpWbdEnEW/e66DyXO1DcgHxIyhP06awu+rHKshZE+lPLIGiwtjo7bsyeuubewwxMw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
-      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.26.tgz",
-      "integrity": "sha512-2rdB3T1/Gp7bv1eQTTm9d1Y1sv9UuJ2LAwOE0Pe2prHKe32UNscj7YS13fRB37d0GAiGNR+Y7ZcW8YjDI8Ns0w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "mime": ">=1.4.1",
     "mongoose": "^8.9.5",
     "next": "^14.2.26",
-    "qs": ">=6.2.4",
     "nodemailer": "^6.10.1",
+    "qs": ">=6.2.4",
     "radix-ui": "^1.0.1",
     "react": "^18",
     "react-day-picker": "^8.10.1",
@@ -87,8 +87,8 @@
     "request": ">=2.68.0",
     "superagent": ">=3.7.0",
     "tailwindcss": "^3.4.17",
-    "tunnel-agent": ">=0.6.0",
     "ts-jest": "^29.3.2",
+    "tunnel-agent": ">=0.6.0",
     "typescript": "^5"
   }
 }

--- a/src/app/create-event/page.tsx
+++ b/src/app/create-event/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useState } from "react";
+// import React, { useState } from "react";
+import React, { useEffect, useState } from "react"; // useEffect to load sessionStorage assignedUser
 import { useRouter } from "next/navigation";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -18,7 +19,7 @@ export default function CreateEventPage() {
   const [startDate, setStartDate] = useState<Date | undefined>();
   const [endDate, setEndDate] = useState<Date | undefined>();
   const [eventDetails, setEventDetails] = useState("");
-  const [user, setUser] = useState("");
+  const [user, setUser] = useState(""); // auto filled now
 
   // Validation state
   const [errors, setErrors] = useState({
@@ -31,6 +32,16 @@ export default function CreateEventPage() {
     user: false,
     invalidDateRange: false,
   });
+
+  // useEffect to read assigned user from sessionStorage
+  useEffect(() => {
+    const assignedUser = sessionStorage.getItem("assignedUser");
+    if (assignedUser) {
+      const userData = JSON.parse(assignedUser);
+      setUser(`${userData.name} (${userData.email})`);
+      sessionStorage.removeItem("assignedUser");
+    }
+  }, []);
 
   // Handle form submission
   const handleSubmit = (e: React.FormEvent) => {
@@ -122,7 +133,11 @@ export default function CreateEventPage() {
           <Button type="button" className="w-1/2 bg-[var(--primary-blue)] text-lg">
             Assign User
           </Button>
-          <Button type="button" className="w-1/2 bg-[var(--primary-blue)] text-lg">
+          <Button
+            type="button"
+            className="w-1/2 bg-[var(--primary-blue)] text-lg"
+            onClick={() => router.push("/create-user")} // make create user button route
+          >
             Create User
           </Button>
         </div>

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -1,57 +1,115 @@
+"use client";
+
 import { User, columns } from "./columns";
 import { DataTable } from "./data-table";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 
-async function getData(): Promise<User[]> {
-  // Fetch data from your API here.
-  return [
-    {
-      id: "728ed52f",
-      name: "John doe",
-      email: "pending",
-      date: "3/8/2025",
-    },
-    {
-      id: "728ed52f",
-      name: "John doe",
-      email: "pending",
-      date: "3/8/2025",
-    },
-    {
-      id: "728ed52f",
-      name: "John doe",
-      email: "pending",
-      date: "3/8/2025",
-    },
-    {
-      id: "728ed52f",
-      name: "John doe",
-      email: "pending",
-      date: "3/8/2025",
-    },
-    {
-      id: "728ed52f",
-      name: "John doe",
-      email: "pending",
-      date: "3/8/2025",
-    },
-  ];
-}
+const initialData: User[] = [
+  {
+    id: "728ed52f",
+    name: "John doe",
+    email: "pending",
+    date: "3/8/2025",
+  },
+  {
+    id: "728ed52f",
+    name: "John doe",
+    email: "pending",
+    date: "3/8/2025",
+  },
+  {
+    id: "728ed52f",
+    name: "John doe",
+    email: "pending",
+    date: "3/8/2025",
+  },
+  {
+    id: "728ed52f",
+    name: "John doe",
+    email: "pending",
+    date: "3/8/2025",
+  },
+  {
+    id: "728ed52f",
+    name: "John doe",
+    email: "pending",
+    date: "3/8/2025",
+  },
+];
 
-export default async function Page() {
-  const data = await getData();
+//export default async function Page() {
+export default function Page() {
+  const router = useRouter();
+  const [data, setData] = useState<User[]>(initialData);
+  const [creatingUser, setCreatingUser] = useState(false);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+
+  const handleCreateUser = () => {
+    const newUser = {
+      id: Date.now().toString(),
+      name,
+      email,
+    };
+    sessionStorage.setItem("assignedUser", JSON.stringify(newUser));
+    router.push("/create-event");
+  };
+
+  const handleCancel = () => {
+    router.push("/create-event");
+  };
 
   return (
     <div className="container mx-auto py-10">
-      <div className="flex items-center justify-between py-5">
-        <Input type="text" placeholder="Search users..." className="w-[500px] text-2xl placeholder:text-xl pxd" />
-      </div>
-      <DataTable columns={columns} data={data} />
-      <div className="flex justify-end py-8 space-x-6">
-        <Button className="bg-red-500 text-white px-4 py-2 text-lg w-[250px]">Cancel</Button>
-        <Button className="bg-[#3A6F8F] text-white px-4 py-2 text-lg w-[250px]">Create User</Button>
-      </div>
+      {!creatingUser ? (
+        <>
+          <div className="flex items-center justify-between py-5">
+            <Input type="text" placeholder="Search users..." className="w-[500px] text-2xl placeholder:text-xl" />
+          </div>
+          <DataTable columns={columns} data={data} />
+          <div className="flex justify-end py-8 space-x-6">
+            <Button className="bg-red-500 text-white px-4 py-2 text-lg w-[250px]" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button
+              className="bg-[#3A6F8F] text-white px-4 py-2 text-lg w-[250px]"
+              onClick={() => setCreatingUser(true)}
+            >
+              Create User
+            </Button>
+          </div>
+        </>
+      ) : (
+        <>
+          {/* ✨ User Creation Form */}
+          <div className="flex flex-col items-center space-y-6 py-10">
+            <h2 className="text-3xl font-bold">Create a New User</h2>
+            <Input
+              placeholder="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-[400px] text-xl"
+            />
+            <Input
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-[400px] text-xl"
+            />
+            <div className="flex space-x-4 pt-6">
+              <Button className="bg-[#3A6F8F] text-white px-6 py-3 text-lg" onClick={handleCreateUser}>
+                Save User
+              </Button>
+              <Button variant="destructive" className="px-6 py-3 text-lg" onClick={() => setCreatingUser(false)}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Developer: Jasmine Ng

Closes #101 

### Pull Request Summary

Admin create new user through users page, when new user is created -> id, name, email saved to sessionStorage under the key assignedUser, after creation -> admin automatically redirected back to create event page where the user field is pre-filled, cancel button added on users page

### Modifications

- handleCreateUser() into users/page.tsx to save new user info to sessionStorage
- handleCancel() into users/page.tsx to redirect without saving user
- useEffect to read assignedUser from sessionStorage when page loads
- pre-fills user field with new user name & email
- clears assignedUser from sessionStorage 
- added cancel button

### Testing Considerations

- assignedUser saved to sessionStorage after creating user
- user redirected to /create-event after creating new user
- create event form is pre-filled after filling out new user form
- assignedUser cleared from sessionStorage
- cancel button

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers
