### PR TITLE
145 lockclosedevents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-scroll-area": "^1.2.3",
         "@radix-ui/react-select": "^2.1.6",
-        "@radix-ui/react-slot": "^1.1.2",
+        "@radix-ui/react-slot": "^1.2.0",
         "@radix-ui/react-tabs": "^1.1.3",
         "@tanstack/react-table": "^8.21.3",
         "bl": ">=1.2.3",
@@ -4145,6 +4145,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-hover-card": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.4.tgz",
@@ -4243,6 +4261,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -4530,6 +4566,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.1.tgz",
@@ -4785,6 +4839,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-select": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.6.tgz",
@@ -5008,6 +5080,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-visually-hidden": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.2.tgz",
@@ -5086,13 +5176,28 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
-      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
+      "integrity": "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.1"
+        "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-scroll-area": "^1.2.3",
     "@radix-ui/react-select": "^2.1.6",
-    "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-tabs": "^1.1.3",
     "@tanstack/react-table": "^8.21.3",
     "bl": ">=1.2.3",

--- a/src/app/client-upload/[event_id]/[document_id]/page.tsx
+++ b/src/app/client-upload/[event_id]/[document_id]/page.tsx
@@ -10,6 +10,7 @@ import { useParams, useRouter } from "next/navigation";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
+import { LoadingSpinner } from "@/components/loadingStates";
 
 // Deprecated function to download document
 // async function downloadDocument(s3DocIdClient: string) {
@@ -149,6 +150,7 @@ const ClientUploadPage: React.FC = () => {
 
   const { isLoaded: userIsLoaded, user } = useUser();
   const [loading, setLoading] = useState<boolean>(true);
+  const [authorized, setAuthorized] = useState<boolean>(false);
   const [eventClerkId, setEventClerkId] = useState<string | null>(null);
   const [eventStatus, setEventStatus] = useState<string | null>(null);
   const [documentClerkId, setDocumentClerkId] = useState<string | null>(null);
@@ -210,18 +212,23 @@ const ClientUploadPage: React.FC = () => {
 
     if (user?.id !== eventClerkId || user?.id !== documentClerkId) {
       router.push("/not-found");
+    } else {
+      setAuthorized(true);
     }
   }, [loading, userIsLoaded, eventClerkId, documentClerkId, user?.id, router]);
 
-  if (loading || !userIsLoaded) {
-    return <div>Loading...</div>;
+  if (loading || !userIsLoaded || !authorized) {
+    return <LoadingSpinner />;
   }
   // Lock the page if the event is completed or cancelled
   if (eventStatus === "Completed" || eventStatus === "Cancelled") {
     return (
       <div className="p-8 text-center">
-        <h2 className="text-2xl font-semibold mb-4">Event is locked</h2>
-        <Button onClick={() => router.back()}>Go Back</Button>
+        <h2 className="text-2xl font-semibold mb-4">{`Event is labeled ${eventStatus.toLowerCase()}`}</h2>
+        <p className="text-lg mb-6">You can no longer upload documents for this event</p>
+        <Button className="bg-[#3A6F8F] text-white px-8 py-4 text-2xl rounded-lg" onClick={() => router.back()}>
+          Go Back
+        </Button>
       </div>
     );
   }

--- a/src/app/client-upload/[event_id]/[document_id]/page.tsx
+++ b/src/app/client-upload/[event_id]/[document_id]/page.tsx
@@ -154,6 +154,7 @@ const ClientUploadPage: React.FC = () => {
   const [documentType, setDocumentType] = useState<string>("");
   const [documentName, setDocumentName] = useState<string>("");
   const [uploading, setUploading] = useState<boolean>(false);
+  const [eventStatus, setEventStatus] = useState<string | null>(null);
 
   const [file, setFile] = useState<File | null>(null);
   const [checklist, setChecklist] = useState<boolean[]>(new Array(8).fill(false));
@@ -181,6 +182,7 @@ const ClientUploadPage: React.FC = () => {
           const event = await eventRes.json();
           const document = await documentRes.json();
           setEventClerkId(event.clerkId);
+          setEventStatus(event.status);
           setDocumentClerkId(document.clerkId);
         } else {
           setEventClerkId(null);
@@ -213,6 +215,15 @@ const ClientUploadPage: React.FC = () => {
 
   if (loading || !userIsLoaded) {
     return <div>Loading...</div>;
+  }
+
+  if (eventStatus === "Completed" || eventStatus === "Cancelled") {
+    return (
+      <div className="p-8 text-center">
+        <h2 className="text-2xl font-semibold mb-4">Event is locked</h2>
+        <Button onClick={() => router.back()}>Go Back</Button>
+      </div>
+    );
   }
 
   const handleChange = (file: File) => {

--- a/src/app/client-upload/[event_id]/page.tsx
+++ b/src/app/client-upload/[event_id]/page.tsx
@@ -203,6 +203,7 @@ const ClientUploadPage: React.FC = () => {
   const { isLoaded: userIsLoaded, user } = useUser();
   const [loading, setLoading] = useState<boolean>(true);
   const [eventClerkId, setEventClerkId] = useState<string | null>(null);
+  const [eventStatus, setEventStatus] = useState<string | null>(null);
   const [documentType, setDocumentType] = useState<string>("");
   const [documentName, setDocumentName] = useState<string>("");
   const [uploading, setUploading] = useState<boolean>(false);
@@ -229,6 +230,7 @@ const ClientUploadPage: React.FC = () => {
         if (eventRes.ok) {
           const event = await eventRes.json();
           setEventClerkId(event.clerkId);
+          setEventStatus(event.status);
         } else {
           setEventClerkId(null);
         }
@@ -258,6 +260,14 @@ const ClientUploadPage: React.FC = () => {
 
   if (loading || !userIsLoaded) {
     return <div>Loading...</div>;
+  }
+  if (eventStatus === "Completed" || eventStatus === "Cancelled") {
+    return (
+      <div className="p-8 text-center">
+        <h2 className="text-2xl font-semibold mb-4">Event is locked</h2>
+        <Button onClick={() => router.back()}>Go Back</Button>
+      </div>
+    );
   }
 
   const handleChange = (file: File) => {

--- a/src/app/client-upload/[event_id]/page.tsx
+++ b/src/app/client-upload/[event_id]/page.tsx
@@ -10,7 +10,7 @@ import { useParams, useRouter } from "next/navigation";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
-import { LoadingSpinner, UnauthorizedState } from "@/components/loadingStates";
+import { LoadingSpinner } from "@/components/loadingStates";
 
 // Deprecated function to download document
 // async function downloadDocument(s3DocIdClient: string) {
@@ -244,14 +244,6 @@ const ClientUploadPage: React.FC = () => {
   };
 
   useEffect(() => {
-    if (isLoaded && user) {
-      setAuthorized(true);
-    } else {
-      setAuthorized(false);
-    }
-  }, [user, isLoaded, eventClerkId]);
-
-  useEffect(() => {
     if (!isLoaded) return;
 
     const fetchData = async () => {
@@ -280,20 +272,34 @@ const ClientUploadPage: React.FC = () => {
     fetchData();
   }, [isLoaded, eventId]);
 
-  if (!isLoaded || loading) {
-    return <LoadingSpinner />;
-  }
+  useEffect(() => {
+    if (loading || !isLoaded) return;
 
-  if (!authorized) {
-    return <UnauthorizedState />;
+    if (!eventClerkId) {
+      router.push("/not-found");
+      return;
+    }
+
+    if (user?.id !== eventClerkId) {
+      router.push("/not-found");
+    } else {
+      setAuthorized(true);
+    }
+  }, [loading, isLoaded, eventClerkId, user?.id, router]);
+
+  if (!isLoaded || loading || !authorized) {
+    return <LoadingSpinner />;
   }
 
   // Lock the page if the event is completed or cancelled
   if (eventStatus === "Completed" || eventStatus === "Cancelled") {
     return (
       <div className="p-8 text-center">
-        <h2 className="text-2xl font-semibold mb-4">Event is locked</h2>
-        <Button onClick={() => router.back()}>Go Back</Button>
+        <h2 className="text-2xl font-semibold mb-4">{`Event is labeled ${eventStatus.toLowerCase()}`}</h2>
+        <p className="text-lg mb-6">You can no longer upload documents for this event</p>
+        <Button className="bg-[#3A6F8F] text-white px-8 py-4 text-2xl rounded-lg" onClick={() => router.back()}>
+          Go Back
+        </Button>
       </div>
     );
   }

--- a/src/app/view/event/[id]/page.tsx
+++ b/src/app/view/event/[id]/page.tsx
@@ -4,12 +4,12 @@ import React, { useState, useEffect } from "react";
 import { useUser } from "@clerk/nextjs";
 import { Button } from "@/components/ui/button";
 import { useParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import EventTile from "@/components/EventTile";
 import { LoadingSpinner, UnauthorizedState, ErrorState } from "@/components/loadingStates";
 import EventDetailsForm from "./components/eventDetailsForm";
 import EventTabContent from "./components/eventTabContent";
 
-// Type definitions
 interface IEventFrontend {
   clerkId: string;
   docIds: string[];
@@ -53,6 +53,8 @@ export default function EventDetailsView() {
   const params = useParams();
   const eventId = Array.isArray(params.id) ? params.id[0] : (params.id ?? "default-id");
   const [activeTab, setActiveTab] = useState<string>("details");
+  const [eventStatus, setEventStatus] = useState<string | null>(null);
+  const router = useRouter();
 
   const venueOptions: IEventFrontend["venue"][] = [
     "Full Facility",
@@ -62,7 +64,6 @@ export default function EventDetailsView() {
     "Other",
   ];
 
-  // Auth check
   useEffect(() => {
     if (isLoaded && user) {
       setAuthorized(true);
@@ -77,7 +78,6 @@ export default function EventDetailsView() {
     }
   }, [user, isLoaded]);
 
-  // Fetch event data
   useEffect(() => {
     if (eventId && eventId !== "default-id") {
       const fetchEvent = async () => {
@@ -91,7 +91,6 @@ export default function EventDetailsView() {
 
           const eventData = await response.json();
 
-          // Convert string dates to Date objects
           const formattedEvent = {
             ...eventData,
             eventDateStart: new Date(eventData.eventDateStart),
@@ -99,10 +98,8 @@ export default function EventDetailsView() {
             createdAt: new Date(eventData.createdAt),
           };
 
-          // Add default temp data fields
           const combinedData = {
             ...formattedEvent,
-            // Default temporary data fields
             clientName: "Client Name",
             adminName: "Admin Name",
             email: "contact@email.com",
@@ -114,6 +111,7 @@ export default function EventDetailsView() {
           setEventData(combinedData);
           setEditCache(combinedData);
           setError(null);
+          setEventStatus(formattedEvent.status);
         } catch (err) {
           console.error("Error fetching event:", err);
           setError("Failed to load event data");
@@ -126,7 +124,6 @@ export default function EventDetailsView() {
     }
   }, [eventId]);
 
-  // Loading and auth states
   if (!isLoaded || loading) {
     return <LoadingSpinner />;
   }
@@ -139,7 +136,6 @@ export default function EventDetailsView() {
     return <ErrorState message={error ? error : "An unknown error occurred"} />;
   }
 
-  // Event handlers
   const handleEditClick = () => {
     setEditCache({ ...eventData });
     setIsEditing(true);
@@ -156,7 +152,6 @@ export default function EventDetailsView() {
     if (!eventData) return;
 
     try {
-      // Extract only the IEvent fields to send to the backend
       const {
         clerkId,
         docIds,
@@ -172,7 +167,6 @@ export default function EventDetailsView() {
         numGuests,
       } = eventData;
 
-      // Prepare payload with only IEvent fields
       const payload = {
         clerkId,
         docIds,
@@ -202,7 +196,6 @@ export default function EventDetailsView() {
 
       const updatedEvent = await response.json();
 
-      // Update the state with the response from the server
       const formattedEvent = {
         ...updatedEvent,
         eventDateStart: new Date(updatedEvent.eventDateStart),
@@ -210,7 +203,6 @@ export default function EventDetailsView() {
         createdAt: new Date(updatedEvent.createdAt),
       };
 
-      // Combine with temporary data
       setEventData({
         ...formattedEvent,
         clientName: eventData.clientName,
@@ -260,85 +252,87 @@ export default function EventDetailsView() {
   };
 
   return (
-    <div className="p-4 md:p-8 lg:p-16">
-      {/* Tab and Buttons Container */}
-      <div className="w-3/4 mx-auto mb-6">
-        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center space-y-3 sm:space-y-0 mb-0">
-          <div className="flex border-b">
-            <Button
-              variant="ghost"
-              onClick={() => setActiveTab("details")}
-              className={`pb-1 px-4 rounded-b-none text-md border-b-2 text-lg ${activeTab === "details" ? "border-black text-black" : "border-transparent text-gray-500 hover:text-black hover:border-gray-300"}`}
-            >
-              Event Details
-            </Button>
-            <Button
-              variant="ghost"
-              onClick={() => setActiveTab("documents")}
-              className={`pb-1 px-4 rounded-b-none text-md border-b-2 text-lg ${activeTab === "documents" ? "border-black text-black" : "border-transparent text-gray-500 hover:text-black hover:border-gray-300"}`}
-            >
-              Documents
-            </Button>
-          </div>
-
-          {isAdmin && (
-            <div className="space-x-2 flex-shrink-0">
-              {isEditing ? (
-                <>
-                  <Button className="w-[5rem] lg:w-[7rem] text-base" variant="outline" onClick={handleSave}>
-                    Save
-                  </Button>
-                  <Button className="w-[5rem] lg:w-[7rem] text-base" variant="outline" onClick={handleCancel}>
-                    Cancel
-                  </Button>
-                  {/* <Button className="w-[5rem] lg:w-[7rem]" variant="outline">
-                    Upload
-                  </Button> */}
-                </>
-              ) : (
-                <Button className="w-[5rem] lg:w-[7rem] text-base" variant="outline" onClick={handleEditClick}>
-                  Edit
-                </Button>
-              )}
+    <>
+      {(eventStatus === "Completed" || eventStatus === "Cancelled") && (
+        <div className="p-4 bg-yellow-100 text-center mb-4 rounded">
+          <span className="font-semibold">Event is locked</span>
+        </div>
+      )}
+      <div className="p-4 md:p-8 lg:p-16">
+        <div className="w-3/4 mx-auto mb-6">
+          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center space-y-3 sm:space-y-0 mb-0">
+            <div className="flex border-b">
+              <Button
+                variant="ghost"
+                onClick={() => setActiveTab("details")}
+                className={`pb-1 px-4 rounded-b-none text-md border-b-2 text-lg ${activeTab === "details" ? "border-black text-black" : "border-transparent text-gray-500 hover:text-black hover:border-gray-300"}`}
+              >
+                Event Details
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => setActiveTab("documents")}
+                className={`pb-1 px-4 rounded-b-none text-md border-b-2 text-lg ${activeTab === "documents" ? "border-black text-black" : "border-transparent text-gray-500 hover:text-black hover:border-gray-300"}`}
+              >
+                Documents
+              </Button>
             </div>
+
+            {isAdmin && eventStatus !== "Completed" && eventStatus !== "Cancelled" && (
+              <div className="space-x-2 flex-shrink-0">
+                {isEditing ? (
+                  <>
+                    <Button className="w-[5rem] lg:w-[7rem] text-base" variant="outline" onClick={handleSave}>
+                      Save
+                    </Button>
+                    <Button className="w-[5rem] lg:w-[7rem] text-base" variant="outline" onClick={handleCancel}>
+                      Cancel
+                    </Button>
+                  </>
+                ) : (
+                  <Button className="w-[5rem] lg:w-[7rem] text-base" variant="outline" onClick={handleEditClick}>
+                    Edit
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex justify-center mb-6">
+          {isEditing && isAdmin ? (
+            <EventDetailsForm eventData={eventData} onUpdateField={handleUpdateField} venueOptions={venueOptions} />
+          ) : (
+            <EventTile
+              id={eventId}
+              eventName={eventData.eventName}
+              eventDateStart={eventData.eventDateStart}
+              eventDateEnd={eventData.eventDateEnd}
+              venue={eventData.venue}
+              numGuests={eventData.numGuests}
+              docsCompleted={eventData.docsCompleted}
+              docsTotal={eventData.docsTotal}
+              imageSrc={eventData.headerImageUrl || ""}
+              variant="detail"
+            />
           )}
         </div>
-      </div>
 
-      {/* Event Tile Section */}
-      <div className="flex justify-center mb-6">
-        {isEditing && isAdmin ? (
-          <EventDetailsForm eventData={eventData} onUpdateField={handleUpdateField} venueOptions={venueOptions} />
-        ) : (
-          <EventTile
-            id={eventId}
-            eventName={eventData.eventName}
-            eventDateStart={eventData.eventDateStart}
-            eventDateEnd={eventData.eventDateEnd}
-            venue={eventData.venue}
-            numGuests={eventData.numGuests}
-            docsCompleted={eventData.docsCompleted}
-            docsTotal={eventData.docsTotal}
-            imageSrc={eventData.headerImageUrl || ""}
-            variant="detail"
-          />
-        )}
+        <EventTabContent
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          eventDetails={eventData.eventDetails}
+          vendorList={eventData.vendorList}
+          documents={eventData.documents}
+          adminName={eventData.adminName}
+          email={eventData.email}
+          phone={eventData.phone}
+          isEditing={isEditing}
+          isAdmin={isAdmin}
+          onUpdateField={handleUpdateField}
+          onRemoveDocument={handleRemoveDocument}
+        />
       </div>
-
-      <EventTabContent
-        activeTab={activeTab}
-        setActiveTab={setActiveTab}
-        eventDetails={eventData.eventDetails}
-        vendorList={eventData.vendorList}
-        documents={eventData.documents}
-        adminName={eventData.adminName}
-        email={eventData.email}
-        phone={eventData.phone}
-        isEditing={isEditing}
-        isAdmin={isAdmin}
-        onUpdateField={handleUpdateField}
-        onRemoveDocument={handleRemoveDocument}
-      />
-    </div>
+    </>
   );
 }

--- a/src/app/view/event/[id]/page.tsx
+++ b/src/app/view/event/[id]/page.tsx
@@ -267,7 +267,7 @@ export default function EventDetailsView() {
   return (
     <div className="p-4 md:p-8 lg:p-16">
       {(eventStatus === "Completed" || eventStatus === "Cancelled") && (
-        <div className="bg-yellow-100 text-black text-center py-2 rounded mb-4">Event is locked</div>
+        <div className="bg-yellow-100 text-black text-center py-2 rounded mb-4">{`Event is labeled ${eventStatus.toLowerCase()}`}</div>
       )}
       {/* Tab and Buttons Container */}
       <div className="w-3/4 mx-auto mb-6">


### PR DESCRIPTION
## Developer: Sharan Krishna

Closes #145

### Pull Request Summary

Added a lock to completed and cancelled events, editing the client-upload pages for event and document ids, also editing the view event page. 

### Modifications

- src/app/client-upload/[event_id]/[document_id]/page.tsx
-  src/app/client-upload/[event_id]/page.tsx
- src/app/view/event/[id]/page.tsx

### Testing Considerations

Already tested on existing cancelled/closed events, retest if needed. 

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

<img width="1512" alt="Screenshot 2025-05-25 at 1 53 01 PM" src="https://github.com/user-attachments/assets/4dd36aec-3fed-4165-b98e-18a2f3a1279e" />
<img width="1512" alt="Screenshot 2025-05-25 at 1 53 08 PM" src="https://github.com/user-attachments/assets/e8305e57-5a04-4cc3-a18a-984d308e02ee" />
<img width="1512" alt="Screenshot 2025-05-25 at 1 53 53 PM" src="https://github.com/user-attachments/assets/866010d9-f84b-4285-a63a-6bb5e6760edf" />
