### PR TITLE
Completed task 143

### DIFF
--- a/src/app/view/event/[id]/components/event.ts
+++ b/src/app/view/event/[id]/components/event.ts
@@ -1,0 +1,28 @@
+export interface IEventFrontend {
+  clerkId: string;
+  docIds: string[];
+  venue: "Full Facility" | "Octagon Barn & Plaza" | "Shed & Courtyard" | "Milking Parlor" | "Other";
+  eventName: string;
+  eventDateStart: Date;
+  eventDateEnd: Date;
+  status: "Upcoming" | "Ongoing" | "Completed" | "Cancelled";
+  eventDetails: string;
+  vendorList: string;
+  createdAt: Date;
+  docsTotal: number;
+  docsCompleted: number;
+  numGuests: number;
+}
+
+export interface ITempEventData {
+  clientName?: string;
+  clientEmail: string;
+  clientPhone: string;
+  documents: IDocument[];
+  headerImageUrl?: string;
+}
+
+interface IDocument {
+  name: string;
+  url: string;
+}

--- a/src/app/view/event/[id]/components/eventDisplay.tsx
+++ b/src/app/view/event/[id]/components/eventDisplay.tsx
@@ -1,20 +1,34 @@
+import React, { useState } from "react";
 import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { IEventFrontend, ITempEventData } from "./event";
 
 interface EventDisplayProps {
+  eventData: (IEventFrontend & ITempEventData) | null;
   eventDetails: string;
   vendorList: string;
   isEditing: boolean;
   isAdmin: boolean;
+  editCache: (IEventFrontend & ITempEventData) | null;
   onUpdateField: (field: string, value: string) => void;
+  onSave: () => void;
+  setEventData: React.Dispatch<React.SetStateAction<(IEventFrontend & ITempEventData) | null>>;
+  setEditCache: React.Dispatch<React.SetStateAction<(IEventFrontend & ITempEventData) | null>>;
 }
 
 export default function EventDisplay({
+  eventData,
   eventDetails,
   vendorList,
+  editCache,
   isEditing,
   isAdmin,
   onUpdateField,
+  onSave,
+  setEventData,
+  setEditCache,
 }: EventDisplayProps) {
+  const [isClientEditing, setIsClientEditing] = useState(false);
   return (
     <div className="space-y-4 bg-gray-200 p-4 rounded-lg shadow-md border border-gray-300">
       <div>
@@ -39,18 +53,67 @@ export default function EventDisplay({
         <label htmlFor="vendorListDisplay" className="block text-lg font-medium mb-1">
           Vendor List:
         </label>
-        {isEditing && isAdmin ? (
-          <Textarea
-            id="vendorListEdit"
-            value={vendorList}
-            onChange={(e) => onUpdateField("vendorList", e.target.value)}
-            rows={4}
-            className="resize-none md:text-base"
-          />
+        {isAdmin ? (
+          isEditing ? (
+            <Textarea
+              id="vendorListEdit"
+              value={vendorList}
+              onChange={(e) => onUpdateField("vendorList", e.target.value)}
+              rows={4}
+              className="resize-none md:text-base"
+            />
+          ) : (
+            <p id="vendorListDisplay" className="text-base whitespace-pre-line">
+              {vendorList}
+            </p>
+          )
         ) : (
-          <p id="vendorListDisplay" className="text-base whitespace-pre-line">
-            {vendorList}
-          </p>
+          <div className="w-full max-w-2xl mx-auto mb-2">
+            {isClientEditing ? (
+              <>
+                <textarea
+                  value={vendorList}
+                  onChange={(e) => onUpdateField("vendorList", e.target.value)}
+                  className="w-full p-3 border rounded-md"
+                  rows={5}
+                />
+                <div className="mt-2 space-x-2">
+                  <Button
+                    variant="outline"
+                    onClick={async () => {
+                      await onSave(); // Save and then hide edit
+                      setIsClientEditing(false);
+                    }}
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setEventData(editCache); // Revert
+                      setIsClientEditing(false);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="whitespace-pre-wrap border p-2 rounded-md bg-gray-50">{vendorList}</p>
+                <Button
+                  className="mt-2"
+                  variant="outline"
+                  onClick={() => {
+                    setEditCache(eventData);
+                    setIsClientEditing(true);
+                  }}
+                >
+                  Edit Vendor List
+                </Button>
+              </>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/src/app/view/event/[id]/components/eventTabContent.tsx
+++ b/src/app/view/event/[id]/components/eventTabContent.tsx
@@ -1,8 +1,8 @@
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import EventDisplay from "./eventDisplay";
 import ContactSection from "./contactSection";
-import DocumentList from "./documentList";
 import DocumentTable from "./documentTable";
+import { IEventFrontend, ITempEventData } from "./event";
 
 interface IDocument {
   name: string;
@@ -12,6 +12,7 @@ interface IDocument {
 interface EventTabContentProps {
   eventId: string;
   activeTab: string;
+  eventData: (IEventFrontend & ITempEventData) | null;
   eventDetails: string;
   eventStatus: "Upcoming" | "Ongoing" | "Completed" | "Cancelled";
   vendorList: string;
@@ -19,15 +20,20 @@ interface EventTabContentProps {
   name?: string;
   email: string;
   phone: string;
+  editCache: (IEventFrontend & ITempEventData) | null;
   isEditing: boolean;
   isAdmin: boolean;
   onUpdateField: (field: string, value: any) => void;
+  onSave: () => void;
   onRemoveDocument: (index: number) => void;
+  setEventData: React.Dispatch<React.SetStateAction<(IEventFrontend & ITempEventData) | null>>;
+  setEditCache: React.Dispatch<React.SetStateAction<(IEventFrontend & ITempEventData) | null>>;
 }
 
 export default function EventTabContent({
   eventId,
   activeTab,
+  eventData,
   eventDetails,
   eventStatus,
   vendorList,
@@ -35,9 +41,13 @@ export default function EventTabContent({
   name,
   email,
   phone,
+  editCache,
   isEditing,
   isAdmin,
   onUpdateField,
+  onSave,
+  setEventData,
+  setEditCache,
   onRemoveDocument,
 }: EventTabContentProps) {
   return (
@@ -48,11 +58,16 @@ export default function EventTabContent({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {/* Left Column - Event Details */}
             <EventDisplay
+              eventData={eventData}
               eventDetails={eventDetails}
               vendorList={vendorList}
+              editCache={editCache}
               isEditing={isEditing}
               isAdmin={isAdmin}
               onUpdateField={onUpdateField}
+              onSave={onSave}
+              setEventData={setEventData}
+              setEditCache={setEditCache}
             />
 
             {/* Right Column - Contact & Documents */}

--- a/src/app/view/event/[id]/page.tsx
+++ b/src/app/view/event/[id]/page.tsx
@@ -48,6 +48,7 @@ export default function EventDetailsView() {
   const [error, setError] = useState<string | null>(null);
 
   const [isEditing, setIsEditing] = useState(false);
+  const [isClientEditing, setIsClientEditing] = useState(false);
   const [eventData, setEventData] = useState<(IEventFrontend & ITempEventData) | null>(null);
   const [editCache, setEditCache] = useState<(IEventFrontend & ITempEventData) | null>(null);
   const params = useParams();
@@ -366,6 +367,57 @@ export default function EventDetailsView() {
           />
         )}
       </div>
+
+      {!isAdmin && activeTab === "details" && (
+        <div className="w-full max-w-2xl mx-auto mt-6">
+          <h2 className="text-xl font-semibold mb-2">Vendor List</h2>
+
+          {isClientEditing ? (
+            <>
+              <textarea
+                value={eventData.vendorList}
+                onChange={(e) => handleUpdateField("vendorList", e.target.value)}
+                className="w-full p-2 border rounded-md"
+                rows={5}
+              />
+              <div className="mt-2 space-x-2">
+                <Button
+                  variant="outline"
+                  onClick={async () => {
+                    await handleSave(); // Save and then hide edit
+                    setIsClientEditing(false);
+                  }}
+                >
+                  Save
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    setEventData(editCache); // Revert
+                    setIsClientEditing(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="whitespace-pre-wrap border p-2 rounded-md bg-gray-50">{eventData.vendorList}</p>
+              <Button
+                className="mt-2"
+                variant="outline"
+                onClick={() => {
+                  setEditCache({ ...eventData });
+                  setIsClientEditing(true);
+                }}
+              >
+                Edit Vendor List
+              </Button>
+            </>
+          )}
+        </div>
+      )}
 
       <EventTabContent
         eventId={eventId}

--- a/src/app/view/event/[id]/page.tsx
+++ b/src/app/view/event/[id]/page.tsx
@@ -4,41 +4,12 @@ import React, { useState, useEffect } from "react";
 import { useUser } from "@clerk/nextjs";
 import { Button } from "@/components/ui/button";
 import { useParams } from "next/navigation";
-import { useRouter } from "next/navigation";
 import EventTile from "@/components/EventTile";
 import { LoadingSpinner, UnauthorizedState, ErrorState } from "@/components/loadingStates";
 import EventDetailsForm from "./components/eventDetailsForm";
 import EventTabContent from "./components/eventTabContent";
+import { IEventFrontend, ITempEventData } from "./components/event";
 import Link from "next/link";
-
-interface IEventFrontend {
-  clerkId: string;
-  docIds: string[];
-  venue: "Full Facility" | "Octagon Barn & Plaza" | "Shed & Courtyard" | "Milking Parlor" | "Other";
-  eventName: string;
-  eventDateStart: Date;
-  eventDateEnd: Date;
-  status: "Upcoming" | "Ongoing" | "Completed" | "Cancelled";
-  eventDetails: string;
-  vendorList: string;
-  createdAt: Date;
-  docsTotal: number;
-  docsCompleted: number;
-  numGuests: number;
-}
-
-interface ITempEventData {
-  clientName?: string;
-  clientEmail: string;
-  clientPhone: string;
-  documents: IDocument[];
-  headerImageUrl?: string;
-}
-
-interface IDocument {
-  name: string;
-  url: string;
-}
 
 export default function EventDetailsView() {
   const { user, isLoaded } = useUser();
@@ -48,7 +19,6 @@ export default function EventDetailsView() {
   const [error, setError] = useState<string | null>(null);
 
   const [isEditing, setIsEditing] = useState(false);
-  const [isClientEditing, setIsClientEditing] = useState(false);
   const [eventData, setEventData] = useState<(IEventFrontend & ITempEventData) | null>(null);
   const [editCache, setEditCache] = useState<(IEventFrontend & ITempEventData) | null>(null);
   const params = useParams();
@@ -57,7 +27,6 @@ export default function EventDetailsView() {
   const [activeTab, setActiveTab] = useState<string>(() => {
     return localStorage.getItem("eventActiveTab") || "details";
   });
-  const router = useRouter();
 
   const venueOptions: IEventFrontend["venue"][] = [
     "Full Facility",
@@ -231,7 +200,7 @@ export default function EventDetailsView() {
         ...formattedEvent,
         clientName: eventData.clientName,
         clientEmail: eventData.clientEmail,
-        cleintPhone: eventData.clientPhone,
+        clientPhone: eventData.clientPhone,
         documents: eventData.documents,
         headerImageUrl: eventData.headerImageUrl,
       });
@@ -368,60 +337,10 @@ export default function EventDetailsView() {
         )}
       </div>
 
-      {!isAdmin && activeTab === "details" && (
-        <div className="w-full max-w-2xl mx-auto mt-6">
-          <h2 className="text-xl font-semibold mb-2">Vendor List</h2>
-
-          {isClientEditing ? (
-            <>
-              <textarea
-                value={eventData.vendorList}
-                onChange={(e) => handleUpdateField("vendorList", e.target.value)}
-                className="w-full p-2 border rounded-md"
-                rows={5}
-              />
-              <div className="mt-2 space-x-2">
-                <Button
-                  variant="outline"
-                  onClick={async () => {
-                    await handleSave(); // Save and then hide edit
-                    setIsClientEditing(false);
-                  }}
-                >
-                  Save
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setEventData(editCache); // Revert
-                    setIsClientEditing(false);
-                  }}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </>
-          ) : (
-            <>
-              <p className="whitespace-pre-wrap border p-2 rounded-md bg-gray-50">{eventData.vendorList}</p>
-              <Button
-                className="mt-2"
-                variant="outline"
-                onClick={() => {
-                  setEditCache({ ...eventData });
-                  setIsClientEditing(true);
-                }}
-              >
-                Edit Vendor List
-              </Button>
-            </>
-          )}
-        </div>
-      )}
-
       <EventTabContent
         eventId={eventId}
         activeTab={activeTab}
+        eventData={eventData}
         eventDetails={eventData.eventDetails}
         eventStatus={eventStatus}
         vendorList={eventData.vendorList}
@@ -429,10 +348,14 @@ export default function EventDetailsView() {
         name={eventData.clientName}
         email={eventData.clientEmail}
         phone={eventData.clientPhone}
+        editCache={editCache}
         isEditing={isEditing}
         isAdmin={isAdmin}
         onUpdateField={handleUpdateField}
+        onSave={handleSave}
         onRemoveDocument={handleRemoveDocument}
+        setEventData={setEventData}
+        setEditCache={setEditCache}
       />
     </div>
   );


### PR DESCRIPTION
## Developer: Jasmine

Closes #143 

### Pull Request Summary

Implement the ability for clients to edit only the Vendor List on the event view page.

### Modifications

- Clients see an editable Vendor List section
- Clicking “Edit Vendor List” reveals a text area)
- “Save” updates the vendor list in MongoDB and hides the editing view
- “Cancel” changes back to the previous vendor list without saving changes
- Admins continue to have access to the full `EventDetailsForm`

### Testing Considerations

- Clients only see the Vendor List section with the Edit button
- Admins still see and can edit the full event form

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers